### PR TITLE
Allow newrelic option

### DIFF
--- a/Chefmap
+++ b/Chefmap
@@ -22,6 +22,8 @@ options:
   "email":
     type: string
     required: true
+  "newrelic":
+    type: string
   "username":
     type: string
     default: MagentoAdmin
@@ -88,6 +90,9 @@ maps:
 - value: {{ setting('email') }}
   targets:
   - attributes://magentostack/config/admin_user/email
+- value: {{ setting('newrelic') }}
+  targets:
+  - attributes://newrelic/license
 - value: {{ setting('username') }}
   targets:
   - attributes://magentostack/config/admin_user/username

--- a/checkmate.yaml
+++ b/checkmate.yaml
@@ -252,6 +252,19 @@ blueprint:
       constraints:
       - regex: '^([a-z0-9A-Z._-]{1,32})$'
         message: must be alpha numeric string with fewer than 32 characters
+    newrelic:
+      label: New Relic License
+      type: string
+      description: License key to enable New Relic
+      help: |
+        This is the license key from New Relic for your application.
+      display-hints:
+        group: application
+        order: 8
+      constrains:
+      - setting: newrelic
+        service: magento
+        resource_type: application
     os:
       label: Operating System
       type: string


### PR DESCRIPTION
We will want to allow New Relic to be enabled, and this can be done by simply providing the New Relic license key as an option and placing it into the attribute `newrelic/license`.
