### PR TITLE
Move magentostack back to :80 and :443

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,8 +2,8 @@
 driver:
   name: vagrant
   network:
-  - ["forwarded_port", {guest: 8080,   host: 8080, auto_correct: true}]
-  - ["forwarded_port", {guest: 8443,   host: 8443, auto_correct: true}]
+  - ["forwarded_port", {guest: 80,   host: 8080, auto_correct: true}]
+  - ["forwarded_port", {guest: 443,   host: 8443, auto_correct: true}]
   customize:
     memory: 1024
 
@@ -12,6 +12,11 @@ provisioner:
   environments_path: test/integration/environments
   require_chef_omnibus: 11.16.4
   attributes:
+    magentostack:
+      web:
+        http_port: '8080'
+        https_port: '8443'
+    
     authorization:
       sudo:
         users: ['vagrant']

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 group :unit do
   gem 'berkshelf', '~> 3'
-  gem 'chefspec'
+  gem 'chefspec', '>= 4'
   gem 'chef-sugar'
 end
 
@@ -23,10 +23,6 @@ end
 
 group :kitchen_rackspace do
   gem 'kitchen-rackspace'
-end
-
-group :kitchen_openstack do
-  gem 'kitchen-openstack'
 end
 
 group :development do

--- a/attributes/apache-fpm.rb
+++ b/attributes/apache-fpm.rb
@@ -4,8 +4,8 @@
 
 # Configure default Magento Vhosts
 default['magentostack']['web']['domain'] = 'localhost'
-default['magentostack']['web']['http_port'] = '8080'
-default['magentostack']['web']['https_port'] = '8443'
+default['magentostack']['web']['http_port'] = '80'
+default['magentostack']['web']['https_port'] = '443'
 default['magentostack']['web']['server_aliases'] = node['fqdn']
 default['magentostack']['web']['ssl_autosigned'] = true
 default['magentostack']['web']['cookbook'] = 'magentostack'


### PR DESCRIPTION
Per discussions, it'd be better to override to :8080 and :8443 in test-kitchen, which I've still done here.
