### PR TITLE
Ensure we run the magento installer exactly once

### DIFF
--- a/files/default/check-magento-installed.php
+++ b/files/default/check-magento-installed.php
@@ -1,0 +1,34 @@
+<?php
+if (version_compare(phpversion(), '5.2.0', '<')===true) {
+  die('ERROR: Whoops, it looks like you have an invalid PHP version. Magento supports PHP 5.2.0 or newer.');
+}
+set_include_path(dirname(__FILE__) . PATH_SEPARATOR . get_include_path());
+require 'app/Mage.php';
+
+try {
+  $app = Mage::app('default');
+
+  $installer = Mage::getSingleton('install/installer_console');
+  /* @var $installer Mage_Install_Model_Installer_Console */
+
+  if ($installer->init($app))
+  {
+    echo "SUCCESS: Did not find any installation of Magento\n";
+    exit(0);
+  }
+
+} catch (Exception $e) {
+  echo "FATAL:\n";
+  Mage::printException($e);
+  exit(2);
+}
+
+// print all errors if there were any
+if ($installer instanceof Mage_Install_Model_Installer_Console) {
+  if ($installer->getErrors()) {
+    foreach ($installer->getErrors() as $error) {
+      echo "FAILED: " . $error . "\n";
+    }
+  }
+}
+exit(1); // don't delete this as this should notify about failed installation

--- a/recipes/magento_configure.rb
+++ b/recipes/magento_configure.rb
@@ -73,11 +73,18 @@ template setup_script do
   )
 end
 
+cookbook_file "#{node['magentostack']['web']['dir']}/check-magento-installed.php" do
+  source 'check-magento-installed.php'
+  user node['apache']['user']
+  group node['apache']['group']
+  mode '0700'
+end
+
 execute setup_script do
   cwd node['magentostack']['web']['dir']
   user node['apache']['user']
   group node['apache']['group']
-  not_if { File.exist?(magento_configured_file) }
+  # not_if { File.exist?(magento_configured_file) }
 end
 
 include_recipe 'magentostack::_magento_redis'

--- a/templates/default/magentostack.sh.erb
+++ b/templates/default/magentostack.sh.erb
@@ -1,3 +1,22 @@
+# run the checker
+CHECK_OUTPUT=$(php -f check-magento-installed.php)
+echo "$CHECK_OUTPUT"
+
+# if magento is already installed, we exit with a good status, chef run continues
+echo "$CHECK_OUTPUT" | grep "Magento is already installed"
+if [ $? -eq 0 ]; then
+  # magento was already installed, match
+  exit 0
+fi
+
+# if the error is NOT about the magento install, we exit with a bad status, chef run blows up
+echo "$CHECK_OUTPUT" | grep "Did not find any installation of Magento"
+if [ $? -ne 0 ]; then
+  # magento was not already installed, and error was *NOT* an expected one
+  exit 1 # short circuit, due an unexpected another error
+fi
+
+# run the installer
 php -f install.php -- \
 --license_agreement_accepted "yes" \
 --locale "<%= node['magentostack']['config']['locale'] %>" \
@@ -23,5 +42,13 @@ php -f install.php -- \
 --admin_username "<%= node['magentostack']['config']['admin_user']['username'] %>" \
 --admin_password "<%= node['magentostack']['config']['admin_user']['password'] %>" \
 --encryption_key "<%= node['magentostack']['config']['encryption_key'] %>" \
---skip_url_validation && touch <%= @magento_configured_file %> || /bin/true
-exit $?
+--skip_url_validation
+INSTALLER_RESULT=$?
+
+# touch the configured file, if installer went okay
+if [ $INSTALLER_RESULT -eq 0 ]; then
+  touch <%= @magento_configured_file %>
+fi
+
+# exit with installer's status
+exit $INSTALLER_RESULT

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 
 # the runlist came from test-kitchen's default suite
 describe 'magentostack all in one demo' do
-  recipes_for_demo = %w(mysql_master varnish redis_single application_php).map { |r| "magentostack::#{r}" }
+  recipes_for_demo = %w(mysql_master varnish redis_single magento_install magento_configure).map { |r| "magentostack::#{r}" }
   before { stub_resources }
   supported_platforms.each do |platform, versions|
     versions.each do |version|
@@ -25,6 +25,10 @@ describe 'magentostack all in one demo' do
 
         property = load_platform_properties(platform: platform, platform_version: version)
         property.to_s # pacify rubocop
+
+        it 'successfully converges' do
+          expect(chef_run).to be_truthy
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/AutomationSupport/magentostack/issues/36, check to see if the installer thinks there is already a magento db installed before trying to run it again. Without multiple nodes, there isn't a nice sustainable way to write tests for this.
