### PR TITLE
New Relic has added curl as a dep upstream

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -21,7 +21,5 @@ cookbook 'ark', git:'https://github.com/burtlo/ark.git', ref: '1f7c092ffe8007340
 cookbook 'openssl', git: 'https://github.com/racker/openssl.git'
 
 cookbook 'kibana', git: 'git@github.com:lusis/chef-kibana.git', branch: 'KIBANA3'
-# newrelic cookbook bug. They have curl as a `recommend`, but it's actually a  dependency
-cookbook 'curl'
 
 cookbook 'newrelic_plugins', git: 'git@github.com:rackspace-cookbooks/newrelic_plugins_chef.git'


### PR DESCRIPTION
Remove explicit call to curl since the upstream cookbook for New Relic has it as a dependency now.

See escapestudios-cookbooks/newrelic#148 for more info.
