### PR TITLE
Updates for cron jobs, php version, and redis cache

### DIFF
--- a/Chefmap
+++ b/Chefmap
@@ -170,7 +170,7 @@ maps:
 - value: "all"
   targets:
   - attributes://magentostack/mysql/databases/db1/privileges
-- source: supported://session-cache/instance/name
+- source: "sessions"
   targets:
   - attributes://magentostack/redis/override_session_name
 - source: supported://session-cache/host
@@ -182,7 +182,7 @@ maps:
 - source: supported://session-cache/instance/interfaces/redis/password
   targets:
   - attributes://magentostack_redis_password_session
-- source: supported://object-cache/instance/name
+- source: "objects"
   targets:
   - attributes://magentostack/redis/override_object_name
 - source: supported://object-cache/host
@@ -194,7 +194,7 @@ maps:
 - source: supported://object-cache/instance/interfaces/redis/password
   targets:
   - attributes://magentostack_redis_password_object
-- source: supported://page-cache/instance/name
+- source: "FPC"
   targets:
   - attributes://magentostack/redis/override_page_name
 - source: supported://page-cache/host

--- a/checkmate.yaml
+++ b/checkmate.yaml
@@ -12,6 +12,7 @@ blueprint:
         - algorithm: ROUND_ROBIN
       relations:
       - magento: http
+      - magento-worker: http
       display-name: Load Balancer
     'magento':
       component:


### PR DESCRIPTION
Included fixes:
- This will setup a master node that will have the cron jobs setup to run on only a single node.
- Ask for a PHP Version and pass it to the attribute.
- Hard code the redis cache name since it's not actually used, but required.
- Link any worker nodes to the LB so they get added once deployed.
