### PR TITLE
Switch to TCP for FastCGI

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -9,6 +9,8 @@ group :integration do
   cookbook 'yum'
 end
 
+cookbook 'varnish', '< 1.1.0'
+
 # Fixes in master@HEAD, but not latest release 2.2.4
 # This line may be removed once a newer version has been released
 cookbook 'redisio', git:'https://github.com/brianbianco/redisio.git'

--- a/attributes/apache-fpm.rb
+++ b/attributes/apache-fpm.rb
@@ -66,6 +66,7 @@ end
 default['php-fpm']['pools'] = {
   'www' => {
     enable: true,
+    listen: '127.0.0.1:9000',
     php_options: {
       'php_admin_flag[opcache.enable]' => '1',
       'php_admin_value[opcache.memory_consumption]' => '256',

--- a/templates/default/fastcgi.conf.erb
+++ b/templates/default/fastcgi.conf.erb
@@ -2,7 +2,7 @@
   AddHandler php5-fcgi .php
   Action php5-fcgi /php5-fcgi
   Alias /php5-fcgi /var/run/php5-fcgi
-  FastCgiExternalServer /var/run/php5-fcgi -socket /var/run/php-fpm-www.sock -flush -idle-timeout 1800
+  FastCgiExternalServer /var/run/php5-fcgi -host 127.0.0.1:9000 -flush -idle-timeout 1800
   <% if node['apache']['version']  == '2.4'%>
   <Directory /var/run>
       Require all granted

--- a/test/fixtures/files/fastcgi
+++ b/test/fixtures/files/fastcgi
@@ -2,5 +2,5 @@
   AddHandler php5-fcgi .php
   Action php5-fcgi /php5-fcgi
   Alias /php5-fcgi /var/run/php5-fcgi
-  FastCgiExternalServer /var/run/php5-fcgi -socket /var/run/php-fpm-www.sock -flush -idle-timeout 1800
+  FastCgiExternalServer /var/run/php5-fcgi -host 127.0.0.1:9000 -flush -idle-timeout 1800
 </IfModule>

--- a/test/fixtures/files/fastcgi_apache2-4
+++ b/test/fixtures/files/fastcgi_apache2-4
@@ -2,7 +2,7 @@
   AddHandler php5-fcgi .php
   Action php5-fcgi /php5-fcgi
   Alias /php5-fcgi /var/run/php5-fcgi
-  FastCgiExternalServer /var/run/php5-fcgi -socket /var/run/php-fpm-www.sock -flush -idle-timeout 1800
+  FastCgiExternalServer /var/run/php5-fcgi -host 127.0.0.1:9000 -flush -idle-timeout 1800
   <Directory /var/run>
       Require all granted
   </Directory>


### PR DESCRIPTION
Per https://trello.com/c/6KqgTzuh/50-chef-switch-php-fpm-to-use-tcp-instead-of-sockets, use TCP instead of unix domain sockets.
