### PR TITLE
Configure master and workers properly

### DIFF
--- a/Chefmap
+++ b/Chefmap
@@ -96,6 +96,9 @@ run-list:
   - elkstack::java
   - elkstack::agent
 maps:
+- value: installer
+  targets:
+  - attributes://magentostack/configure_method
 - value: {{ setting('http_port') }}
   targets:
   - attributes://magentostack/web/http_port
@@ -347,6 +350,9 @@ run-list:
   - elkstack::java
   - elkstack::agent
 maps:
+- value: template
+  targets:
+  - attributes://magentostack/configure_method
 - value: {{ setting('http_port') }}
   targets:
   - attributes://magentostack/web/http_port


### PR DESCRIPTION
We now have the ability to template out the local.xml, so this allows us
to run the installer on 1 node only. This sets the "master" node as that
1 node, and let's the rest setup via templates.
