### PR TITLE
Don't put chain in config if missing

### DIFF
--- a/recipes/apache-fpm.rb
+++ b/recipes/apache-fpm.rb
@@ -125,7 +125,8 @@ if node['magentostack']['web']['ssl_custom']
 
   node.set['magentostack']['web']['ssl_cert'] = custom_ssl.certificate
   node.set['magentostack']['web']['ssl_key'] = custom_ssl.key
-  node.set['magentostack']['web']['ssl_chain'] = custom_ssl.chain if custom_ssl.chain
+  node.set['magentostack']['web']['ssl_chain'] = custom_ssl.chain
+
 end
 
 # Fast-cgi configuration
@@ -153,7 +154,7 @@ end
       https_port node['magentostack']['web']['https_port']
       ssl_cert node['magentostack']['web']['ssl_cert']
       ssl_key node['magentostack']['web']['ssl_key']
-      ssl_chain node['magentostack']['web']['ssl_chain']
+      lazy { ssl_chain node['magentostack']['web']['ssl_chain'] if ::File.exist?(node.set['magentostack']['web']['ssl_chain']) }
     end
   end
 end


### PR DESCRIPTION
Ensure that the virtual host doesn't configure a chain file if the file itself is missing on disk. I ended up not having an easy way to test this via unit test since it's inside the `web_app` LWRP that isn't going to run.
