### PR TITLE
Add Rackspace bits

### DIFF
--- a/Chefmap
+++ b/Chefmap
@@ -90,6 +90,7 @@ options:
 run-list:
   recipes:
   - platformstack
+  - platformstack::rackops_rolebook
   - magentostack::apache-fpm
   - magentostack::magento_install
   - magentostack::newrelic
@@ -363,6 +364,7 @@ options:
 run-list:
   recipes:
   - platformstack
+  - platformstack::rackops_rolebook
   - magentostack::apache-fpm
   - magentostack::magento_install
   - magentostack::newrelic
@@ -567,6 +569,7 @@ options:
 run-list:
   recipes:
   - platformstack
+  - platformstack::rackops_rolebook
   - magentostack::mysql_master
   - magentostack::mysql_holland
 maps:
@@ -632,6 +635,7 @@ options:
 run-list:
   recipes:
   - platformstack
+  - platformstack::rackops_rolebook
   - magentostack::redis_single
   - magentostack::redis_configure
 maps:
@@ -672,6 +676,7 @@ supports:
 run-list:
   recipes:
   - platformstack
+  - platformstack::rackops_rolebook
   - magentostack::redis_page
   - magentostack::redis_object
   - magentostack::redis_session
@@ -719,6 +724,7 @@ run-list:
   - apt
   - parted
   - platformstack
+  - platformstack::rackops_rolebook
   - magentostack::partition_nfs_disk
   - magentostack::nfs_server
 maps:
@@ -772,6 +778,7 @@ options:
 run-list:
   recipes:
   - platformstack
+  - platformstack::rackops_rolebook
   - elkstack::java
   - elkstack::cluster
   - elkstack::acl


### PR DESCRIPTION
This will add supported requested items to a Checkmate deployed Magento so Rackspace can support it.
