### PR TITLE
NewRelic license must default to '', not false

### DIFF
--- a/Chefmap
+++ b/Chefmap
@@ -78,7 +78,7 @@ options:
     required: true
   "newrelic":
     type: boolean
-    default: false
+    default: ''
     required: true
 #  "database_privileges":
 #    type: string


### PR DESCRIPTION
- RE: https://github.com/escapestudios-cookbooks/newrelic/issues/178
- Was causing convergence failures of `Option license must be a kind of String! You passed false.`
