### PR TITLE
Support for modman and varnish

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,7 @@
 driver:
   name: vagrant
   network:
+  - ["forwarded_port", {guest: 8181,   host: 8181, auto_correct: true}]
   - ["forwarded_port", {guest: 8080,   host: 8080, auto_correct: true}]
   - ["forwarded_port", {guest: 8443,   host: 8443, auto_correct: true}]
   customize:
@@ -13,6 +14,9 @@ provisioner:
   require_chef_omnibus: true
   attributes:
     magentostack:
+      varnish:
+        secret: "9a160c7a-22f2-45a7-b5ab-ec32dc060714\n"
+        listen_port: 8181
       web:
         http_port: '8080'
         https_port: '8443'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,12 @@ UnusedBlockArgument:
 CyclomaticComplexity:
   Max: 20
 
+Metrics/ModuleLength:
+  Max: 250
+
+Performance/ParallelAssignment:
+  Enabled: false
+
 AllCops:
   Include:
     - '**/metadata.rb'

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Supported Platforms
 
 - CentOS 6.5
-- Ubuntu 12.04 (partially, not for Mysql)
-- Ubuntu 14.04 (partially, not for Mysql)
+- Ubuntu 12.04 (untested)
+- Ubuntu 14.04 (untested)
 
 ## Supported Magento version
 Community Edition >= 1.9
@@ -64,6 +64,15 @@ See instructions in [the certificate cookbook](https://github.com/atomic-penguin
 # Only for Magento CE <1.9 or EE < 1.14 (not supported yet)
 apache2::mod_fastcgi doesn't allow to compile mod_Fastcgi from source, therefore it will not use the mod_fastcgi patched version. It means Ubuntu with Magento CE <1.9 or EE < 1.14 might have some bugs. [References](http://www.magentocommerce.com/boards/m/viewthread/229253/)
 --->
+
+### varnish and modman
+In order to use Varnish, include the varnish recipe in your wrapper or ensure you're set to community edition, where Varnish is enabled by default. This installs varnish using default settings, as well as modman and installs the turpentine module for Magento.
+
+Under `System > Configuration > Web > Secure` change the Offloader header value to `HTTP_X_FORWARDED_PROTO` (from the default SSL_OFFLOADED) and make sure the Base URL has `https` for the protocol, then save.
+
+You should also ensure you set `node['magentostack']['varnish']['secret']` to something on each server, and then also set that value in the Administration GUI in Magento, and do an initial flush of the Varnish cache.
+
+See the [main page about turpentine](http://www.magentocommerce.com/magento-connect/turpentine-varnish-cache.html), the [installation instructions for turpentine](https://github.com/nexcess/magento-turpentine/wiki/Installation), and the [modman Github site](https://github.com/colinmollenhour/modman), for more information and documentation.
 
 ### gluster
 - what it does

--- a/attributes/modman.rb
+++ b/attributes/modman.rb
@@ -1,0 +1,3 @@
+# modules to install/configure by default
+# ex. default['magentostack']['modman']['magento-turpentine'] = 'https://github.com/nexcess/magento-turpentine.git'
+default['magentostack']['modman'] = {}

--- a/attributes/varnish.rb
+++ b/attributes/varnish.rb
@@ -1,0 +1,2 @@
+default['magentostack']['varnish']['listen_port'] = 8080
+default['magentostack']['varnish']['secret'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,8 @@ depends 'stack_commons', '>= 0.0.50'
 depends 'platformstack', '~> 3.1'
 depends 'rackspacecloud', '~> 0.1'
 depends 'rackspace_iptables', '~> 1.7'
+depends 'varnish', '~> 2.2.0'
+depends 'modman', '~> 2.2.1'
 
 depends 'apache2', '~> 3.0'
 depends 'apt', '~> 2.7'

--- a/recipes/modman.rb
+++ b/recipes/modman.rb
@@ -1,0 +1,43 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: magentostack
+# Recipe:: modman
+#
+# Copyright 2014, Rackspace Hosting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# TODO: Figure out how to do this by automation:
+#
+# If you want to use modman you need to configure Magento to allow
+# rendering templates that are being symlinked. Please go to
+# System > Configuration > Advanced > Developer and enable Allow Symlinks.
+
+include_recipe 'modman' unless ::File.exist?("#{node['modman']['install_path']}/modman")
+modman_path = node['apache']['docroot_dir']
+modman_basedir = node['magentostack']['web']['dir'].gsub("#{modman_path}/", '')
+modman 'initialize modman one time' do
+  basedir modman_basedir
+  path modman_path
+  action :init
+  not_if { ::File.exist?("#{node['apache']['docroot_dir']}/.modman") }
+end
+
+node['magentostack']['modman'].each_pair do |module_name, module_url|
+  modman module_url do
+    action :clone
+    path modman_path
+    not_if { ::File.exist?("#{node['apache']['docroot_dir']}/.modman/#{module_name}") }
+  end
+end

--- a/recipes/varnish.rb
+++ b/recipes/varnish.rb
@@ -1,0 +1,65 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: magentostack
+# Recipe:: varnish
+#
+# Copyright 2014, Rackspace Hosting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include_recipe 'chef-sugar'
+include_recipe 'yum-epel' if rhel?
+include_recipe 'magentostack::modman'
+
+varnish_install 'varnish' do
+  vendor_repo true # needed for varnish >= 3
+  action :install
+end
+
+file '/etc/varnish/secret' do
+  content node['magentostack']['varnish']['secret']
+  mode 0600
+  only_if { node['magentostack']['varnish']['secret'] }
+end
+
+varnish_default_config 'varnish-config-magento' do
+  listen_port node['magentostack']['varnish']['listen_port']
+  parameters(
+    # default for varnish
+    'thread_pools' => '4',
+    'thread_pool_min' => '5',
+    'thread_pool_max' => '500',
+    'thread_pool_timeout' => '300',
+
+    # recommended by turpentine
+    'esi_syntax' => '0x2',
+    'cli_buffer' => '16384'
+  )
+  action :configure
+end
+
+# Apache on :80, but LBs point at Varnish on :8080
+varnish_default_vcl 'varnish-vcl' do
+  backend_port node['magentostack']['web']['http_port'].to_i
+  action :configure
+end
+
+varnish_log 'varnish-log' do
+  action :configure
+end
+
+modman 'https://github.com/nexcess/magento-turpentine.git' do
+  action :clone
+  path node['apache']['docroot_dir']
+  not_if { ::File.exist?("#{node['apache']['docroot_dir']}/.modman/magento-turpentine") }
+end

--- a/test/fixtures/cookbooks/wrapper/recipes/default.rb
+++ b/test/fixtures/cookbooks/wrapper/recipes/default.rb
@@ -8,6 +8,11 @@
 # This wrapper's default recipe is intended to build a single node magento installation.
 # Add more recipes in the wrapper for other topologies/configurations of magentostack.
 
+def enterprise?
+  node['magentostack'] && node['magentostack']['flavor'] == 'enterprise'
+end
+
+# we still install redis for sessions and objects, even in CE
 %w(
   wrapper::_redis_password_single
   magentostack::redis_single
@@ -29,6 +34,8 @@
 end
 
 # if enterprise edition, also enable the FPC for testing
-if node['magentostack'] && node['magentostack']['flavor'] == 'enterprise'
+if enterprise?
   include_recipe 'magentostack::_magento_fpc'
+else
+  include_recipe 'magentostack::varnish'
 end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -9,6 +9,7 @@ require_relative 'apache_examples'
 require_relative 'php_examples'
 require_relative 'mysql_examples'
 require_relative 'magento_admin_examples'
+require_relative 'varnish_examples'
 
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:/bin:/usr/bin:$PATH'

--- a/test/integration/helpers/serverspec/varnish_examples.rb
+++ b/test/integration/helpers/serverspec/varnish_examples.rb
@@ -1,0 +1,33 @@
+shared_examples_for 'magento under varnish' do |args|
+  describe file('/usr/local/bin/modman') do
+    it { should exist }
+  end
+
+  describe file('/var/www/html/.modman') do
+    it { should exist }
+  end
+
+  describe service('varnish') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe port(8181) do
+    it { should be_listening }
+  end
+
+  # verify SSL flag works
+  describe command("wget -qO- localhost:8080/admin --header='X-Forwarded-Proto: https'") do
+    its(:stdout) { should match(/Congratulations/) }
+  end
+
+  # verify varnish works
+  describe command('wget -qO- localhost:8181') do
+    its(:stdout) { should match(/Congratulations/) }
+  end
+
+  # verify varnish with SSL flag works
+  describe command("wget -qO- localhost:8181/admin --header='X-Forwarded-Proto: https'") do
+    its(:stdout) { should match(/Congratulations/) }
+  end
+end


### PR DESCRIPTION
- Add support for modman and installing additional modules via hash of name => git url, fixes #177.
- Add support for varnish and turpentine (using modman), you must still enable turpentine in the UI, fixes #174.
- Reviewed CE testing, and it looks like we're doing quite a bit of testing, fixes #176.
