### PR TITLE
Allow `none` as an option for install method

### DIFF
--- a/checkmate.yaml
+++ b/checkmate.yaml
@@ -249,8 +249,10 @@ blueprint:
         choice:
         - name: "Git"
           value: git
+        - name: "No Install"
+          value: "none"
       constraints:
-      - in: ["git"]
+      - in: ["git", "none"]
         message: unsupported install method
       constrains:
       - setting: install_method


### PR DESCRIPTION
Customers are requesting that we setup infra but not install Magento. This will allow us to do that within Checkmate.
