### PR TITLE
Change default `php_max_children` to update UI

### DIFF
--- a/checkmate.yaml
+++ b/checkmate.yaml
@@ -906,6 +906,8 @@ flavors:
           - setting: disk
             service: db-master
             resource_type: compute
+        php_max_children:
+          default: '27'
       meta-data:
         flavor: Performance 1
         flavor-weight: 2
@@ -1031,6 +1033,8 @@ flavors:
           - setting: disk
             service: db-master
             resource_type: compute
+        php_max_children:
+          default: '60'
       meta-data:
         flavor: Performance 2
         flavor-weight: 3
@@ -1233,6 +1237,8 @@ flavors:
           - setting: disk
             service: db-replica
             resource_type: compute
+        php_max_children:
+          default: '32'
       meta-data:
         flavor: Enterprise 1
         flavor-weight: 4
@@ -1435,6 +1441,8 @@ flavors:
           - setting: disk
             service: db-replica
             resource_type: compute
+        php_max_children:
+          default: '40'
       meta-data:
         flavor: Enterprise 2
         flavor-weight: 5


### PR DESCRIPTION
This updated the UI of Checkmate when a flavor is picked to match the suggested `php_max_children`.
