### PR TITLE
Fix java, elkstack usage

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -21,6 +21,7 @@ cookbook 'elkstack'
 # but not install it; causing it to fail on `upload`
 cookbook 'monit'
 cookbook 'chef-provisioning'
+cookbook 'java'
 
 # pin newrelic until the releases stabalize
 cookbook 'newrelic', '<= 2.10'

--- a/Chefmap
+++ b/Chefmap
@@ -101,7 +101,7 @@ run-list:
   - magentostack::magento_configure
   - magentostack::magento_admin
   - magentostack::nfs_client
-  - elkstack::java
+  - java::default
   - elkstack::agent
 maps:
 - value: installer
@@ -394,7 +394,7 @@ run-list:
   - magentostack::_find_mysql
   - magentostack::magento_configure
   - magentostack::nfs_client
-  - elkstack::java
+  - java::default
   - elkstack::agent
 maps:
 - value: template
@@ -612,7 +612,7 @@ run-list:
   - platformstack::rackops_rolebook
   - magentostack::mysql_master
   - magentostack::mysql_holland
-  - elkstack::java
+  - java::default
   - elkstack::agent
 maps:
 - value: {{ setting('database_root_password') }}
@@ -680,7 +680,7 @@ run-list:
   - platformstack::rackops_rolebook
   - magentostack::redis_single
   - magentostack::redis_configure
-  - elkstack::java
+  - java::default
   - elkstack::agent
 maps:
 - value: {{ setting('port') }}
@@ -725,7 +725,7 @@ run-list:
   - magentostack::redis_object
   - magentostack::redis_session
   - magentostack::redis_configure
-  - elkstack::java
+  - java::default
   - elkstack::agent
 maps:
 - value: "not needed"
@@ -772,7 +772,7 @@ run-list:
   - platformstack::rackops_rolebook
   - magentostack::configure_disk
   - magentostack::nfs_server
-  - elkstack::java
+  - java::default
   - elkstack::agent
 maps:
 - value: "/dev/xvdb"
@@ -826,7 +826,7 @@ run-list:
   recipes:
   - platformstack
   - platformstack::rackops_rolebook
-  - elkstack::java
+  - java::default
   - elkstack::cluster
   - elkstack::acl
 maps:
@@ -879,7 +879,7 @@ run-list:
   - platformstack
   - platformstack::rackops_rolebook
   - magentostack::nfs_server
-  - elkstack::java
+  - java::default
   - elkstack::cluster
   - elkstack::acl
 maps:

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Magento Admin:
       "recipe[magentostack::magento_configure]",
       "recipe[magentostack::magento_admin]",
       "recipe[magentostack::nfs_client]",
-      "recipe[elkstack::java]",
+      "recipe[java::default]",
       "recipe[elkstack::agent]"
     ]
 }
@@ -301,7 +301,7 @@ Magento Worker
       "recipe[magentostack::_find_mysql]",
       "recipe[magentostack::magento_configure]",
       "recipe[magentostack::nfs_client]",
-      "recipe[elkstack::java]",
+      "recipe[java::default]",
       "recipe[elkstack::agent]"
     ]
 }
@@ -314,7 +314,7 @@ Magento MySQL Master
       "recipe[platformstack]",
       "recipe[magentostack::mysql_master]",
       "recipe[magentostack::mysql_holland]",
-      "recipe[elkstack::java]",
+      "recipe[java::default]",
       "recipe[elkstack::agent]"
     ]
 }
@@ -327,7 +327,7 @@ Magento Redis
       "recipe[platformstack]",
       "recipe[magentostack::redis_single]",
       "recipe[magentostack::redis_configure]",
-      "recipe[elkstack::java]",
+      "recipe[java::default]",
       "recipe[elkstack::agent]"
     ]
 }
@@ -337,7 +337,7 @@ Magento Elkstack
 ```json
 {
     "run_list": [
-      "recipe[elkstack::java]",
+      "recipe[java::default]",
       "recipe[elkstack::cluster]",
       "recipe[elkstack::acl]"
     ]
@@ -352,7 +352,7 @@ Magento NFS Server
       "recipe[platformstack]",
       "recipe[magentostack::configure_disk]",
       "recipe[magentostack::nfs_server]",
-      "recipe[elkstack::java]",
+      "recipe[java::default]",
       "recipe[elkstack::agent]"
     ]
 }

--- a/tests.yaml
+++ b/tests.yaml
@@ -131,7 +131,7 @@ test-cases:
               - "magentostack::_find_mysql"
               - "magentostack::magento_configure"
               - "magentostack::nfs_client"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "application"
       "1":
@@ -205,7 +205,7 @@ test-cases:
               - "platformstack::rackops_rolebook"
               - "magentostack::mysql_master"
               - "magentostack::mysql_holland"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "database"
       "3":
@@ -274,7 +274,7 @@ test-cases:
               - "magentostack::_find_mysql"
               - "magentostack::magento_configure"
               - "magentostack::nfs_client"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "application"
       "4":
@@ -348,7 +348,7 @@ test-cases:
               - "platformstack::rackops_rolebook"
               - "magentostack::mysql_master"
               - "magentostack::mysql_holland"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "database"
       "6":
@@ -417,7 +417,7 @@ test-cases:
               - "magentostack::_find_mysql"
               - "magentostack::magento_configure"
               - "magentostack::nfs_client"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "application"
       "7":
@@ -491,7 +491,7 @@ test-cases:
               - "platformstack::rackops_rolebook"
               - "magentostack::mysql_master"
               - "magentostack::mysql_holland"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "database"
       "9":
@@ -603,7 +603,7 @@ test-cases:
               - "magentostack::magento_configure"
               - "magentostack::magento_admin"
               - "magentostack::nfs_client"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "application"
       "11":
@@ -677,7 +677,7 @@ test-cases:
               - "platformstack::rackops_rolebook"
               - "magentostack::mysql_master"
               - "magentostack::mysql_holland"
-              - "elkstack::java"
+              - "java::default"
               - "elkstack::agent"
         "type": "database"
       "kibana user":


### PR DESCRIPTION
- Change from elkstack::java to java::default (elkstack no longer wraps this)
- Add java cookbook to Berksfile to make elkstack available to people using magentostack.

Part of breaking apart #188.
