### PR TITLE
Fix for no Varnish secret

### DIFF
--- a/recipes/varnish.rb
+++ b/recipes/varnish.rb
@@ -28,7 +28,7 @@ varnish_install 'varnish' do
 end
 
 file '/etc/varnish/secret' do
-  content node['magentostack']['varnish']['secret']
+  content node['magentostack']['varnish']['secret'].to_s # in case it's false
   mode 0600
   only_if { node['magentostack']['varnish']['secret'] }
 end


### PR DESCRIPTION
We shouldn't pass `false` to the file resource. This prevents that while still guarding against a missing value.