### PR TITLE
stub database host for chefspec

### DIFF
--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -30,6 +30,8 @@ def node_resources(node)
   node.set['disk']['device'] = '/dev/xvde'
   node.set['disk']['fs'] = 'ext4'
   node.set['magentostack']['config']['encryption_key'] = 'secret-crypt-key'
+  # _magento_installer relies on database host being not false
+  node.set['magentostack']['config']['db']['host'] = '10.0.0.3'
 end
 
 # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
to account for the new fail check in `_magento_installer.rb`
\---
```
Failures:

  1) magentostack::magento enterprise with cloudfiles install on Centos 6.5 gets magento and extract it
     Failure/Error: end.converge('magentostack::magento_install',
     RuntimeError:
       Could not find a database host for Magento
```