### PR TITLE
Don't pre-create git checkout dir

### DIFF
--- a/recipes/apache-fpm.rb
+++ b/recipes/apache-fpm.rb
@@ -143,6 +143,8 @@ end
 
 # Create documentroot
 directory node['magentostack']['web']['dir'] do
+  user node['apache']['user']
+  group node['apache']['group']
   action :create
   not_if { File.exist?(node['magentostack']['web']['dir']) }
 end

--- a/recipes/magento_install.rb
+++ b/recipes/magento_install.rb
@@ -108,10 +108,6 @@ when 'git'
 
   # Run the checkout into /var/www/html/magento
   magento_dir = "#{node['apache']['docroot_dir']}/magento"
-  directory magento_dir do
-    user node['apache']['user']
-    group node['apache']['group']
-  end
   git magento_dir do
     repository node['magentostack']['git_repository']
     revision node['magentostack']['git_revision']


### PR DESCRIPTION
- Don't pre-create the git checkout dir
- When creating the document root, be sure it is owned by Apache