### PR TITLE
Remove `.with(action: [...])` array data

### DIFF
--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -18,6 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'magentostack::_mysql_logging'
 include_recipe 'stack_commons::mysql_master'
+include_recipe 'magentostack::_mysql_logging'
 node.save unless Chef::Config[:solo] # make me searchable right away!

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -18,5 +18,5 @@
 # limitations under the License.
 #
 
-include_recipe 'magentostack::_mysql_logging'
 include_recipe 'stack_commons::mysql_slave'
+include_recipe 'magentostack::_mysql_logging'

--- a/test/unit/spec/apache-fpm_spec.rb
+++ b/test/unit/spec/apache-fpm_spec.rb
@@ -81,7 +81,7 @@ describe 'magentostack::apache-fpm' do
             end
 
             expect(chef_run).to delete_link('/etc/httpd/sites-enabled/ssl.conf')
-            expect(chef_run).to_not openssl_x509('/etc/httpd/ssl/localhost.pem')
+            expect(chef_run).to openssl_x509('/etc/httpd/ssl/localhost.pem')
           end
         end
 

--- a/test/unit/spec/magento_admin_spec.rb
+++ b/test/unit/spec/magento_admin_spec.rb
@@ -21,11 +21,11 @@ describe 'magentostack::magento_admin' do
         it 'creates redis clean magento cronjob' do
           expect(chef_run).to install_yum_package('git')
           expect(chef_run).to checkout_git('/root/cm_redis_tools')
-          expect(chef_run).to create_cron('redis_tag_cleanup').with(action: [:create])
+          expect(chef_run).to create_cron('redis_tag_cleanup').with(action: :create)
         end
         it 'creates normal magento cronjob and set permissions on cron.sh' do
           expect(chef_run).to touch_file('/var/www/html/magento/cron.sh').with(mode: '755')
-          expect(chef_run).to create_cron('magento_cron').with(minute: '*/5', user: 'apache', command: '/var/www/html/magento/cron.sh', action: [:create])
+          expect(chef_run).to create_cron('magento_cron').with(minute: '*/5', user: 'apache', command: '/var/www/html/magento/cron.sh', action: :create)
         end
       end
     end

--- a/test/unit/spec/magento_cloudfiles_spec.rb
+++ b/test/unit/spec/magento_cloudfiles_spec.rb
@@ -32,7 +32,7 @@ describe 'magentostack::magento enterprise with cloudfiles install' do
 
         it 'gets magento and extract it' do
           expect(chef_run).to create_rackspacecloud_file("#{Chef::Config[:file_cache_path]}/magento-ee-1.14.0.1.tar.gz")
-          expect(chef_run).to put_ark('magento').with(action: [:put], url: "file://#{Chef::Config[:file_cache_path]}/magento-ee-1.14.0.1.tar.gz")
+          expect(chef_run).to put_ark('magento').with(action: :put, url: "file://#{Chef::Config[:file_cache_path]}/magento-ee-1.14.0.1.tar.gz")
         end
       end
     end

--- a/test/unit/spec/magento_spec.rb
+++ b/test/unit/spec/magento_spec.rb
@@ -31,7 +31,7 @@ describe 'magentostack::magento recipes' do
         end
 
         it 'gets magento and extract it' do
-          expect(chef_run).to put_ark('magento').with(action: [:put], url: 'http://www.magentocommerce.com/downloads/assets/1.9.1.1/magento-1.9.1.1.tar.gz')
+          expect(chef_run).to put_ark('magento').with(action: :put, url: 'http://www.magentocommerce.com/downloads/assets/1.9.1.1/magento-1.9.1.1.tar.gz')
         end
 
         it 'runs Magento installer' do


### PR DESCRIPTION
It seems chefspec would prefer `.with(action: :foo)` over `.with(action: [:foo])` for these tests now. This is likely something that changed in chef 12.4.