### PR TITLE
Ensure .git is forbidden

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :unit do
   gem 'berkshelf', '~> 3'
   gem 'chefspec', '>= 4.2'
   gem 'chef-sugar'
+  gem 'chef', '>= 12.4.1'
 end
 
 group :kitchen_common do

--- a/templates/default/apache2/magento_vhost.erb
+++ b/templates/default/apache2/magento_vhost.erb
@@ -58,4 +58,22 @@
     Require host 127.0.0.1
     <% end -%>
   </Location>
+
+  # hide .git and .git+ (gitignore, gitmodules, etc)
+  # do not allow .git version control files to be issued
+  <DirectoryMatch "^/.*/\.git+/">
+    Order deny,allow
+    Deny from all
+  </DirectoryMatch>
+  <Files ~ "^\.git">
+      Order allow,deny
+      Deny from all
+  </Files>
+
+  # also hide .svn directories
+  <DirectoryMatch \.svn>
+    Order allow,deny
+    Deny from all
+  </DirectoryMatch>
+
 </VirtualHost>

--- a/test/integration/helpers/serverspec/default_examples.rb
+++ b/test/integration/helpers/serverspec/default_examples.rb
@@ -38,6 +38,14 @@ shared_examples_for 'magento community edition' do
     its(:stdout) { should match(/Magento Demo Store/) }
   end
 
+  # ensure git dirs aren't exposed
+  describe command('wget -O- localhost:8080/.git/ 2>&1') do
+    its(:stdout) { should match(/Forbidden/) }
+    its(:stdout) { should match(/403/) }
+    its(:stdout) { should_not match(/Index of/) }
+    its(:exit_status) { should_not eq 0 }
+  end
+
   describe file('/mnt/magento_media') do
     it { should be_directory }
   end

--- a/test/unit/spec/magento_admin_spec.rb
+++ b/test/unit/spec/magento_admin_spec.rb
@@ -19,7 +19,7 @@ describe 'magentostack::magento_admin' do
           end.converge(described_recipe)
         end
         it 'creates redis clean magento cronjob' do
-          expect(chef_run).to install_yum_package('git')
+          expect(chef_run).to install_package('git')
           expect(chef_run).to checkout_git('/root/cm_redis_tools')
           expect(chef_run).to create_cron('redis_tag_cleanup').with(action: [:create])
         end


### PR DESCRIPTION
- Ensure Apache rejects /.git/ requests.
- Bump chef to 12.4.1 or later, to fix array vs. symbol rspec test failures