### PR TITLE
Added excution logic to the varnish_config

### DIFF
--- a/attributes/varnish.rb
+++ b/attributes/varnish.rb
@@ -20,3 +20,4 @@
 
 default['magentostack']['varnish']['listen_port'] = 8080
 default['magentostack']['varnish']['secret'] = false
+default['magentostack']['varnish']['config'] = true

--- a/recipes/varnish.rb
+++ b/recipes/varnish.rb
@@ -58,6 +58,7 @@ end
 varnish_default_vcl 'varnish-vcl' do
   backend_port node['magentostack']['web']['http_port'].to_i
   action :configure
+  only_if { node['magentostack']['varnish']['config'] }
 end
 
 varnish_log 'varnish-log' do


### PR DESCRIPTION
This is so that downstream users of the cookbook can disable this code block and use a custom default.vcl for varnish.