### PR TITLE
Allow additional SSH wrapper settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 group :lint do
   gem 'foodcritic', '>= 4.0'
   gem 'foodcritic-rackspace-rules', '>= 1.3.2'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.33.0', require: false
 end
 
 group :unit do

--- a/attributes/magento.rb
+++ b/attributes/magento.rb
@@ -41,6 +41,7 @@ default['magentostack']['git_repository'] = 'git@github.com:example/deployment.g
 default['magentostack']['git_revision'] = 'master' # e.g. staging, testing, dev
 default['magentostack']['git_deploykey'] = nil
 default['magentostack']['git_submodules'] = false
+default['magentostack']['git_ssh_args'] = ['StrictHostKeyChecking=no']
 
 # Database creation by the mysql cookbook
 normal['magentostack']['mysql']['databases']['magento_database']['mysql_user'] = 'magento_user'

--- a/recipes/magento_install.rb
+++ b/recipes/magento_install.rb
@@ -97,13 +97,18 @@ when 'git'
     mode '0700'
   end
 
+  str_ssh_args = ''
+  node['magentostack']['git_ssh_args'].each do |a|
+    str_ssh_args << "-o \"#{a}\" "
+  end
+
   # Write an SSH wrapper for git checkouts
   git_ssh_wrapper = "#{Chef::Config[:file_cache_path]}/git_ssh_wrapper.sh"
   template git_ssh_wrapper do
     user node['apache']['user']
     group node['apache']['group']
     mode '0700'
-    variables(keyfile: id_deploy)
+    variables(keyfile: id_deploy, ssh_args: str_ssh_args)
   end
 
   # Run the checkout into /var/www/html/magento

--- a/templates/default/git_ssh_wrapper.sh.erb
+++ b/templates/default/git_ssh_wrapper.sh.erb
@@ -4,4 +4,4 @@
 #
 # Rendered by Chef - local changes will be replaced
 
-/usr/bin/env ssh -o "StrictHostKeyChecking=no" -i "<%= @keyfile %>" $1 $2
+/usr/bin/env ssh <%= @ssh_args %> -i "<%= @keyfile %>" $1 $2


### PR DESCRIPTION
In order to checkout on non-standard ports, as supported by Github and others, allow additional git ssh wrapper options to be passed to the git checkout.