### PR TITLE
Fix chain value in SSL certs

### DIFF
--- a/attributes/apache-fpm.rb
+++ b/attributes/apache-fpm.rb
@@ -44,8 +44,8 @@ default['magentostack']['web']['dir'] = "#{node['apache']['docroot_dir']}/magent
 site_name = node['magentostack']['web']['domain']
 default['magentostack']['web']['ssl_key'] = "#{node['apache']['dir']}/ssl/#{site_name}.key"
 default['magentostack']['web']['ssl_cert'] = "#{node['apache']['dir']}/ssl/#{site_name}.pem"
-# default['magentostack']['web']['ssl_chain'] = nil
-# default['magentostack']['web']['ssl_custom_basename'] = nil
+default['magentostack']['web']['ssl_chain'] = nil
+default['magentostack']['web']['ssl_custom_basename'] = nil
 
 # Install php dependencies for Magento
 default['magentostack']['php']['version'] = 'php55'

--- a/recipes/apache-fpm.rb
+++ b/recipes/apache-fpm.rb
@@ -133,7 +133,6 @@ if node['magentostack']['web']['ssl_custom']
   node.set['magentostack']['web']['ssl_cert'] = custom_ssl.certificate
   node.set['magentostack']['web']['ssl_key'] = custom_ssl.key
   node.set['magentostack']['web']['ssl_chain'] = custom_ssl.chain
-
 end
 
 # Fast-cgi configuration
@@ -167,7 +166,7 @@ vhosts.each do |site|
       https_port node['magentostack']['web']['https_port']
       ssl_cert node['magentostack']['web']['ssl_cert']
       ssl_key node['magentostack']['web']['ssl_key']
-      lazy { ssl_chain node['magentostack']['web']['ssl_chain'] if ::File.exist?(node.set['magentostack']['web']['ssl_chain']) }
+      ssl_chain node['magentostack']['web']['ssl_chain']
     end
     notifies :restart, 'service[apache2]', :delayed
     notifies :restart, 'service[php-fpm]', :delayed


### PR DESCRIPTION
Don't use lazy {} for the chain, just pass nil if there's no value. Lazy wasn't working with chef definitions.

Fixes #233.